### PR TITLE
Add support for different Broadcom HCAs

### DIFF
--- a/opal/mca/btl/openib/mca-btl-openib-device-params.ini
+++ b/opal/mca/btl/openib/mca-btl-openib-device-params.ini
@@ -334,9 +334,17 @@ max_inline_data = 72
 
 # Broadcom NetXtreme-E RDMA Ethernet Controller
 
-[Broadcom Cumulus]
+[Broadcom BCM57XXX]
 vendor_id = 0x14e4
-vendor_part_id = 0x16d7
+vendor_part_id = 0x1605,0x1606,0x1614,0x16c0,0x16c1,0x16ce,0x16cf,0x16d6,0x16d7,0x16d8,0x16d9,0x16df,0x16e2,0x16e3,0x16e5,0x16eb,0x16ed,0x16ef,0x16f0,0x16f1
+use_eager_rdma = 1
+mtu = 1024
+receive_queues = P,65536,256,192,128
+max_inline_data = 96
+
+[Broadcom BCM58XXX]
+vendor_id = 0x14e4
+vendor_part_id = 0xd800,0xd802,0xd804
 use_eager_rdma = 1
 mtu = 1024
 receive_queues = P,65536,256,192,128


### PR DESCRIPTION
Adds device ids of different Broadcom adapters from
BCM57XXX and BCM58XXX family of HCAs.

Signed-off-by: Selvin Xavier <selvin.xavier@broadcom.com>